### PR TITLE
Add action parameter to get_time_off_requests

### DIFF
--- a/PyBambooHR/PyBambooHR.py
+++ b/PyBambooHR/PyBambooHR.py
@@ -627,7 +627,7 @@ class PyBambooHR(object):
         return r.json()
         # return utils.transform_whos_out(r.content)
 
-    def get_time_off_requests(self, start_date=None, end_date=None, status=None, type=None, employee_id=None):
+    def get_time_off_requests(self, start_date=None, end_date=None, status=None, type=None, employee_id=None, action=None):
         start_date = utils.resolve_date_argument(start_date)
         end_date = utils.resolve_date_argument(end_date)
 
@@ -642,6 +642,8 @@ class PyBambooHR(object):
             params['type'] = type
         if employee_id:
             params['employeeId'] = employee_id
+        if action:
+            params['action'] = action
 
         r = self._query('time_off/requests', params, raw=True)
         return r.json()


### PR DESCRIPTION
The `/time_off/requests/` endpoint supports an `action` query parameter to filter to only requests which the current user can approve. [1] Here we add support for passing that parameter through to the API if specified.

[1] https://documentation.bamboohr.com/reference#time-off-get-time-off-requests-1